### PR TITLE
LLM-controlled animation duration logic added

### DIFF
--- a/src/server/authorization/authorized_users.json
+++ b/src/server/authorization/authorized_users.json
@@ -3,6 +3,7 @@
     "bruceatwood1@gmail.com",
     "goshdam@mit.edu",
     "fabiocat@mit.edu",
-    "fabctn93@gmail.com"
+    "fabctn93@gmail.com",
+    "hasantahabagci@gmail.com"
   ]
 }


### PR DESCRIPTION
### Summary

Implemented support for the LLM to decide animation duration for more natural pacing.

---

### 🔧 Changes

* [x] **Server (animation\_handler.py)**

  * Added optional `duration` param (0.5–10s, default 3s)
  * Validates input + sends duration in event payload

* [x] **Client (TalkingHeadWrapper.tsx)**

  * Handles duration from server
  * Applies duration to gestures/moods
  * Falls back to defaults if missing
