### PR TITLE
fix: prevent Google Auth screen from showing when authentication is disabled

### DIFF
--- a/src/client/react/src/contexts/AuthContext.tsx
+++ b/src/client/react/src/contexts/AuthContext.tsx
@@ -78,7 +78,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   const [user, setUser] = useState<User | null>(null);
   const [token, setToken] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
-  const [googleAuthEnabled, setGoogleAuthEnabled] = useState(true);
+  const [googleAuthEnabled, setGoogleAuthEnabled] = useState(false);
 
   useEffect(() => {
     // Check auth status and existing token on mount


### PR DESCRIPTION
## Summary
- Changed default `googleAuthEnabled` state from `true` to `false` in AuthContext
- Prevents Google Auth screen from appearing when authentication is disabled in the application

## Changes
- Modified `src/client/react/src/contexts/AuthContext.tsx` to set `googleAuthEnabled` initial state to `false`

## Test plan
- [ ] Verify Google Auth prompt does not appear when authentication is disabled
- [ ] Test application startup behavior
- [ ] Confirm auth flow works correctly when Google Auth is explicitly enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)