### PR TITLE
Add CPU and GPU deployment modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,14 @@ More detailed instructions for setting up the [client](src/client/react/README.m
 docker compose up --build
 ```
 
+This default Docker setup builds the server for CPU / non-GPU deployment.
+
+To build with GPU-oriented extras and request a GPU-enabled container runtime:
+
+```bash
+docker compose -f docker-compose.yaml -f docker-compose.gpu.yaml up --build
+```
+
 #### 3b. Run manually in two different tabs of your terminal (recommended)
 
 - **Start the server:**
@@ -115,6 +123,16 @@ docker compose up --build
   conda install -c conda-forge "ffmpeg=7.*"
   pip install -r requirements.txt
   python main.py
+  ```
+
+  For a GPU-oriented install on Linux, use:
+  ```bash
+  pip install -r requirements.gpu.txt
+  ```
+
+  To force local inference onto CPU even on a machine with an accelerator, set:
+  ```bash
+  export RIVERST_COMPUTE_DEVICE=cpu
   ```
 
 - **Start the client:**

--- a/docker-compose.gpu.yaml
+++ b/docker-compose.gpu.yaml
@@ -1,0 +1,8 @@
+services:
+  server:
+    build:
+      args:
+        RIVERST_DEPLOYMENT_TARGET: gpu
+    environment:
+      RIVERST_COMPUTE_DEVICE: auto
+    gpus: all

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,11 +5,15 @@ services:
     build:
       context: ./src/server
       dockerfile: Dockerfile
+      args:
+        RIVERST_DEPLOYMENT_TARGET: ${RIVERST_DEPLOYMENT_TARGET:-cpu}
     container_name: riverst_server
     ports:
       - "7860:7860"
     env_file:
       - ./src/server/.env
+    environment:
+      RIVERST_COMPUTE_DEVICE: ${RIVERST_COMPUTE_DEVICE:-auto}
     volumes:
       - ./src/server/sessions:/app/sessions
 

--- a/docs/gpu-cpu-deployment-plan.md
+++ b/docs/gpu-cpu-deployment-plan.md
@@ -1,0 +1,43 @@
+# GPU and Non-GPU Deployment Plan
+
+## Goal
+
+Allow Riverst to deploy in either of these modes without code changes:
+
+- [x] CPU / non-GPU deployment
+- [x] GPU-capable deployment
+
+## Findings
+
+After reviewing the repository, no server function strictly requires a GPU to execute. The GPU-sensitive paths are all local-model or local-inference paths where acceleration improves latency or throughput.
+
+### GPU-sensitive functions and classes
+
+- [x] `src/server/bot/utils/device_utils.py:get_best_device`
+- [x] `src/server/bot/processors/audio/resampling_helper.py:AudioResamplingHelper._torchaudio_resample`
+- [x] `src/server/bot/processors/speech/lipsync_processor.py:predict_phonemes_from_waveform`
+- [x] `src/server/bot/processors/speech/lipsync_processor.py:load_cupe_model`
+- [x] `src/server/bot/processors/speech/lipsync_processor.py:LipsyncProcessor.__init__`
+- [x] `src/server/bot/processors/speech/lipsync_processor.py:LipsyncProcessor._warm_up`
+- [x] `src/server/bot/processors/speech/lipsync_processor.py:LipsyncProcessor._preprocess_audio`
+- [x] `src/server/bot/processors/speech/lipsync_processor.py:LipsyncProcessor._run_lipsync`
+- [x] `src/server/bot/core/component_factory.py:BotComponentFactory._build_stt_service`
+- [x] `src/server/bot/core/component_factory.py:BotComponentFactory._build_tts_service`
+- [x] `src/server/bot/processors/video/processor.py:VideoProcessor.__init__`
+- [x] `src/server/bot/processors/video/processor.py:VideoProcessor._run_pose_in_background`
+- [x] `src/server/bot/processors/audio/analyzer.py:AudioAnalyzer.analyze_audio`
+
+## Decisions
+
+- [x] Add a runtime device policy via `RIVERST_COMPUTE_DEVICE=auto|cpu`
+- [x] Add a Docker build target via `RIVERST_DEPLOYMENT_TARGET=cpu|gpu`
+- [x] Add a GPU compose override for `gpus: all`
+- [x] Keep CPU deployments functional when ONNX export dependencies are unavailable
+- [x] Add a small test suite for the runtime device policy
+
+## Implementation Notes
+
+- CPU deployments now default to `requirements.txt`
+- GPU deployments install `requirements.gpu.txt`
+- Runtime device selection is centralized in `bot.utils.device_utils`
+- Pose processing falls back to the PyTorch YOLO model if ONNX export is unavailable

--- a/notes/first_steps_to_deploy.md
+++ b/notes/first_steps_to_deploy.md
@@ -6,7 +6,8 @@ This guide explains step-by-step how to deploy the Riverst project on AWS using 
 
 ## 1. Create an AWS EC2 instance
 
-- Choose `g4dn.xlarge` as the instance type or more powerful (you may need a more powerful gpu if you want to run models locally without experiencing any unpleasant delay).
+- For GPU deployment, choose `g4dn.xlarge` as the instance type or more powerful.
+- For non-GPU deployment, choose a general-purpose Ubuntu instance sized for your traffic and disable accelerator usage with `RIVERST_COMPUTE_DEVICE=cpu`.
 - Use a Linux (Ubuntu) machine.
 - Set the storage volume to **64 GB** (or larger).
 - Open these ports in the security group:
@@ -36,6 +37,8 @@ ssh -i your-key.pem ubuntu@your-elastic-ip
 ---
 
 ## 4. Install NVIDIA drivers
+
+Only required for GPU deployment.
 
 ```bash
 sudo apt update
@@ -160,6 +163,7 @@ cd riverst/src/server
 pip install -r requirements.txt
 cp .env.example .env
 # Edit `.env` to configure your settings following .env.example
+# For CPU-only deployment add: RIVERST_COMPUTE_DEVICE=cpu
 # Edit the src/server/config/authorized_users.json
 
 # [In a tmux tab]

--- a/src/server/Dockerfile
+++ b/src/server/Dockerfile
@@ -4,6 +4,9 @@ FROM python:3.12
 # Set working directory
 WORKDIR /app
 
+ARG RIVERST_DEPLOYMENT_TARGET=cpu
+ENV RIVERST_DEPLOYMENT_TARGET=${RIVERST_DEPLOYMENT_TARGET}
+
 # System packages and Rust installation
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git build-essential g++ curl \
@@ -14,8 +17,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Copy application code
 COPY . .
 
-# Install any needed packages specified in requirements.txt
-RUN pip install --no-cache-dir -r requirements.txt
+# Install dependencies for the selected deployment target
+RUN case "$RIVERST_DEPLOYMENT_TARGET" in \
+      cpu) requirements_file="requirements.txt" ;; \
+      gpu) requirements_file="requirements.gpu.txt" ;; \
+      *) echo "Unsupported RIVERST_DEPLOYMENT_TARGET: $RIVERST_DEPLOYMENT_TARGET" >&2; exit 1 ;; \
+    esac \
+    && pip install --no-cache-dir -r "$requirements_file"
 
 
 # Expose port

--- a/src/server/README.md
+++ b/src/server/README.md
@@ -5,8 +5,8 @@
 1. Set up and activate your virtual environment:
 
 ```bash
-conda create -n riverst python=3.11 -y
-conda activate riverst
+python -m venv .venv
+source .venv/bin/activate
 ```
 
 2. Install python dependencies
@@ -14,9 +14,15 @@ conda activate riverst
 pip install -r requirements.txt
 ```
 
+For a GPU-oriented Linux deployment, install:
+```bash
+pip install -r requirements.gpu.txt
+```
+
 3. Copy `env.example` to `.env` and configure params:
    - Set your `OPENAI_API_KEY` for LLM and TTS services
    - Set your env variables (you can follow the instructions in the `.env.example` file)
+   - Set `RIVERST_COMPUTE_DEVICE=cpu` if you want to disable GPU/MPS usage at runtime
 
 **Note**: Not all API KEYS are strictly required. Only if you want to use a remote service, you need to expose the corresponding API KEY
 
@@ -55,4 +61,11 @@ python main.py
 ```bash
 docker build --no-cache -t fastapi-server .
 docker run -p 7860:7860 --env-file .env fastapi-server
+```
+
+To build a GPU-oriented image instead:
+
+```bash
+docker build --no-cache --build-arg RIVERST_DEPLOYMENT_TARGET=gpu -t fastapi-server .
+docker run --gpus all -p 7860:7860 --env-file .env fastapi-server
 ```

--- a/src/server/bot/processors/video/processor.py
+++ b/src/server/bot/processors/video/processor.py
@@ -41,15 +41,27 @@ class VideoProcessor(FrameProcessor):
 
         if self.enable_pose:
             logger.info("Initializing YOLO pose model...")
-            yolo_model = YOLO("yolo11n-pose.pt")
-            yolo_model.export(format="onnx")  # Creates 'yolo11n-pose.onnx'
-            self.pose_inferencer = YOLO("yolo11n-pose.onnx")
+            self.pose_inferencer = self._load_pose_inferencer()
 
             dummy_img = np.random.randint(
                 0, 255, (camera_out_height, camera_out_width, 3), dtype=np.uint8
             )
             _ = self.pose_inferencer(dummy_img)
             logger.info("YOLO warmed up.")
+
+    def _load_pose_inferencer(self):
+        """Prefer ONNX when available, but keep CPU deployments functional without it."""
+        yolo_model = YOLO("yolo11n-pose.pt")
+        try:
+            yolo_model.export(format="onnx")  # Creates 'yolo11n-pose.onnx'
+            logger.info("Using ONNX-backed YOLO pose inferencer.")
+            return YOLO("yolo11n-pose.onnx")
+        except Exception as exc:
+            logger.warning(
+                "ONNX pose export unavailable, falling back to PyTorch YOLO pose model: "
+                f"{exc}"
+            )
+            return yolo_model
 
     async def _run_pose_in_background(self, img: np.ndarray) -> None:
         if self._pose_lock.locked():

--- a/src/server/bot/utils/device_utils.py
+++ b/src/server/bot/utils/device_utils.py
@@ -1,27 +1,60 @@
 """Device detection utilities for PyTorch."""
 
+import os
+
 import torch
 from torch import device as TorchDevice
 
+COMPUTE_DEVICE_ENV_VAR = "RIVERST_COMPUTE_DEVICE"
+DEPLOYMENT_TARGET_ENV_VAR = "RIVERST_DEPLOYMENT_TARGET"
+DEFAULT_DEVICE_ORDER = ("cuda", "mps", "cpu")
+VALID_COMPUTE_DEVICE_POLICIES = {"auto", "cpu"}
 
-def get_best_device(options=["cuda", "mps", "cpu"]) -> TorchDevice:
-    """Returns the "best" available torch device according to the following strategy:
 
-    1. Use CUDA if available.
-    2. If not, use MPS (Metal Performance Shaders) if available.
-    3. Otherwise, fall back to CPU.
+def get_compute_device_policy() -> str:
+    """Return the configured runtime compute device policy.
 
-    Returns:
-        torch.device: The best available torch device ('cuda', 'mps', or 'cpu').
+    `auto` prefers accelerated backends when available.
+    `cpu` forces all local model execution onto CPU.
     """
-    if torch.cuda.is_available() and "cuda" in options:
+    policy = os.getenv(COMPUTE_DEVICE_ENV_VAR, "auto").strip().lower()
+    if policy not in VALID_COMPUTE_DEVICE_POLICIES:
+        raise ValueError(
+            f"Invalid {COMPUTE_DEVICE_ENV_VAR}={policy!r}. "
+            f"Expected one of {sorted(VALID_COMPUTE_DEVICE_POLICIES)}."
+        )
+    return policy
+
+
+def get_deployment_target() -> str:
+    """Return the configured deployment target used by packaging/docs."""
+    return os.getenv(DEPLOYMENT_TARGET_ENV_VAR, "cpu").strip().lower()
+
+
+def get_best_device(options=None) -> TorchDevice:
+    """Return the best available torch device for the current runtime policy."""
+    requested_options = list(options or DEFAULT_DEVICE_ORDER)
+    policy = get_compute_device_policy()
+
+    if policy == "cpu":
+        if "cpu" not in requested_options:
+            raise ValueError(
+                "CPU-only runtime policy requested, but 'cpu' is not in the "
+                f"allowed device options: {requested_options}."
+            )
+        return torch.device("cpu")
+
+    if torch.cuda.is_available() and "cuda" in requested_options:
         return torch.device("cuda")
-    elif (
+
+    if (
         hasattr(torch.backends, "mps")
         and torch.backends.mps.is_available()
-        and "mps" in options
+        and "mps" in requested_options
     ):
         return torch.device("mps")
-    else:
-        # Fallback to CPU
+
+    if "cpu" in requested_options:
         return torch.device("cpu")
+
+    raise ValueError(f"No supported device found for options: {requested_options}.")

--- a/src/server/env.example
+++ b/src/server/env.example
@@ -3,6 +3,7 @@
 # -------------------------
 OPENAI_API_KEY=""             # OpenAI API key for language models
 HF_TOKEN=""                   # Hugging Face access token for downloading models (required for many models, including ASR Whisper)
+RIVERST_COMPUTE_DEVICE="auto" # Runtime device policy for local models: "auto" prefers accelerators, "cpu" disables GPU/MPS usage
 
 # -------------------------
 # TURN Server Configuration (for WebRTC) - You can ignore these for local testing

--- a/src/server/requirements.gpu.txt
+++ b/src/server/requirements.gpu.txt
@@ -1,0 +1,4 @@
+-r requirements.txt
+onnx>=1.12.0
+onnxslim>=0.1.67
+onnxruntime-gpu

--- a/src/server/tests/test_device_utils.py
+++ b/src/server/tests/test_device_utils.py
@@ -1,0 +1,71 @@
+import os
+import sys
+import unittest
+import types
+import importlib
+from unittest import mock
+
+
+def make_fake_torch(cuda_available=False, mps_available=False):
+    torch_module = types.ModuleType("torch")
+    torch_module.device = lambda name: name
+    torch_module.cuda = types.SimpleNamespace(is_available=lambda: cuda_available)
+    torch_module.backends = types.SimpleNamespace(
+        mps=types.SimpleNamespace(is_available=lambda: mps_available)
+    )
+    return torch_module
+
+
+class DeviceUtilsTest(unittest.TestCase):
+    def setUp(self):
+        self.modules_backup = {
+            "torch": sys.modules.get("torch"),
+            "bot.utils.device_utils": sys.modules.get("bot.utils.device_utils"),
+            "bot.utils": sys.modules.get("bot.utils"),
+            "bot": sys.modules.get("bot"),
+        }
+        sys.modules["torch"] = make_fake_torch()
+        self.device_utils = importlib.import_module("bot.utils.device_utils")
+
+    def tearDown(self):
+        for module_name, module in self.modules_backup.items():
+            if module is None:
+                sys.modules.pop(module_name, None)
+            else:
+                sys.modules[module_name] = module
+
+    def test_default_policy_is_auto(self):
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop(self.device_utils.COMPUTE_DEVICE_ENV_VAR, None)
+            self.assertEqual(self.device_utils.get_compute_device_policy(), "auto")
+
+    def test_cpu_policy_forces_cpu(self):
+        with mock.patch.dict(
+            os.environ,
+            {self.device_utils.COMPUTE_DEVICE_ENV_VAR: "cpu"},
+            clear=False,
+        ):
+            device = self.device_utils.get_best_device(options=["cuda", "mps", "cpu"])
+            self.assertEqual(str(device), "cpu")
+
+    def test_invalid_policy_raises(self):
+        with mock.patch.dict(
+            os.environ,
+            {self.device_utils.COMPUTE_DEVICE_ENV_VAR: "invalid"},
+            clear=False,
+        ):
+            with self.assertRaises(ValueError):
+                self.device_utils.get_compute_device_policy()
+
+    def test_cpu_policy_requires_cpu_option(self):
+        with mock.patch.dict(
+            os.environ,
+            {self.device_utils.COMPUTE_DEVICE_ENV_VAR: "cpu"},
+            clear=False,
+        ):
+            with self.assertRaises(ValueError):
+                self.device_utils.get_best_device(options=["cuda"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add explicit CPU vs GPU deployment controls for the server build and runtime
- document the GPU-sensitive functions and deployment workflow
- keep CPU deployments working when ONNX pose export dependencies are missing

## Testing
- python3 -m unittest discover -s tests
