### PR TITLE
Clear avatar localStorage on login and logout to prevent cross-account leakage

### DIFF
--- a/src/client/react/src/contexts/AuthContext.tsx
+++ b/src/client/react/src/contexts/AuthContext.tsx
@@ -93,9 +93,11 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
           const bypassResponse = await axios.post('/api/auth/bypass');
           const { access_token, user: userData } = bypassResponse.data;
 
+          localStorage.setItem('auth_token', access_token);
+          localStorage.removeItem('selectedAvatar');
+          localStorage.removeItem('uploadedAvatars');
           setToken(access_token);
           setUser(userData);
-          localStorage.setItem('auth_token', access_token);
           setIsLoading(false);
           return;
         }
@@ -151,13 +153,12 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
       const { access_token, user: userData } = response.data;
 
-      setToken(access_token);
-      setUser(userData);
-
-      // Save token; clear any avatar state left by a previous user's session.
+      // Clear avatar state before updating React state to prevent stale reads.
       localStorage.setItem('auth_token', access_token);
       localStorage.removeItem('selectedAvatar');
       localStorage.removeItem('uploadedAvatars');
+      setToken(access_token);
+      setUser(userData);
 
     } catch (error: any) {
       console.error('Login failed:', error);
@@ -173,11 +174,11 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
    * Clears user and token from state and localStorage.
    */
   const logout = () => {
-    setUser(null);
-    setToken(null);
     localStorage.removeItem('auth_token');
     localStorage.removeItem('selectedAvatar');
     localStorage.removeItem('uploadedAvatars');
+    setUser(null);
+    setToken(null);
   };
 
   const value: AuthContextType = {

--- a/src/client/react/src/contexts/AuthContext.tsx
+++ b/src/client/react/src/contexts/AuthContext.tsx
@@ -16,6 +16,18 @@ const withAuthHeaders = (token: string | null, config: any = {}) => ({
   headers: { ...config.headers, Authorization: `Bearer ${token}` }
 });
 
+const STORAGE_KEYS = {
+  AUTH_TOKEN: 'auth_token',
+  SELECTED_AVATAR: 'selectedAvatar',
+  UPLOADED_AVATARS: 'uploadedAvatars',
+} as const;
+
+const clearUserSessionStorage = () => {
+  localStorage.removeItem(STORAGE_KEYS.AUTH_TOKEN);
+  localStorage.removeItem(STORAGE_KEYS.SELECTED_AVATAR);
+  localStorage.removeItem(STORAGE_KEYS.UPLOADED_AVATARS);
+};
+
 export const makeAuthenticatedRequest = (token: string | null) => ({
   get: (url: string, config = {}) => axios.get(url, withAuthHeaders(token, config)),
   post: (url: string, data: any, config = {}) => axios.post(url, data, withAuthHeaders(token, config)),
@@ -93,16 +105,15 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
           const bypassResponse = await axios.post('/api/auth/bypass');
           const { access_token, user: userData } = bypassResponse.data;
 
-          localStorage.setItem('auth_token', access_token);
-          localStorage.removeItem('selectedAvatar');
-          localStorage.removeItem('uploadedAvatars');
+          clearUserSessionStorage();
+          localStorage.setItem(STORAGE_KEYS.AUTH_TOKEN, access_token);
           setToken(access_token);
           setUser(userData);
           setIsLoading(false);
           return;
         }
 
-        const savedToken = localStorage.getItem('auth_token');
+        const savedToken = localStorage.getItem(STORAGE_KEYS.AUTH_TOKEN);
         if (savedToken) {
           setToken(savedToken);
           // Verify token and get user info
@@ -153,10 +164,8 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
       const { access_token, user: userData } = response.data;
 
-      // Clear avatar state before updating React state to prevent stale reads.
-      localStorage.setItem('auth_token', access_token);
-      localStorage.removeItem('selectedAvatar');
-      localStorage.removeItem('uploadedAvatars');
+      clearUserSessionStorage();
+      localStorage.setItem(STORAGE_KEYS.AUTH_TOKEN, access_token);
       setToken(access_token);
       setUser(userData);
 
@@ -174,9 +183,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
    * Clears user and token from state and localStorage.
    */
   const logout = () => {
-    localStorage.removeItem('auth_token');
-    localStorage.removeItem('selectedAvatar');
-    localStorage.removeItem('uploadedAvatars');
+    clearUserSessionStorage();
     setUser(null);
     setToken(null);
   };

--- a/src/client/react/src/contexts/AuthContext.tsx
+++ b/src/client/react/src/contexts/AuthContext.tsx
@@ -154,8 +154,10 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
       setToken(access_token);
       setUser(userData);
 
-      // Save token to localStorage
+      // Save token; clear any avatar state left by a previous user's session.
       localStorage.setItem('auth_token', access_token);
+      localStorage.removeItem('selectedAvatar');
+      localStorage.removeItem('uploadedAvatars');
 
     } catch (error: any) {
       console.error('Login failed:', error);
@@ -174,6 +176,8 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     setUser(null);
     setToken(null);
     localStorage.removeItem('auth_token');
+    localStorage.removeItem('selectedAvatar');
+    localStorage.removeItem('uploadedAvatars');
   };
 
   const value: AuthContextType = {


### PR DESCRIPTION
When a user logs out or a new user logs in, selectedAvatar and uploadedAvatars are removed from localStorage so a previous user's avatar selection is never inherited by the next user.