### PR TITLE
Fix KIVA acronym expansion

### DIFF
--- a/demo-site/src/content/kiva.js
+++ b/demo-site/src/content/kiva.js
@@ -2,7 +2,7 @@
  * KIVA Project section content for the #kiva section.
  */
 export const kiva = {
-  tagline: 'KIVA (Kids Interactive Vocabulary Acquisition) uses Riverst to help young learners build academic vocabulary through natural conversations with an AI avatar. Watch the pitch to learn more.',
+  tagline: 'KIVA (Knowledge Integration and Vocabulary Accelerator) uses Riverst to help young learners build academic vocabulary through natural conversations with an AI avatar. Watch the pitch to learn more.',
   pitchVideo: {
     youtubeId: 'LMfxs7uhNnE',
     title: 'KIVA Project Pitch',


### PR DESCRIPTION
KIVA stands for Knowledge Integration and Vocabulary Accelerator, not Kids Interactive Vocabulary Acquisition.